### PR TITLE
Overwork CMakeLists.txt files for cuda phase retrieval

### DIFF
--- a/cuda_phase-retrieval/CMakeLists.txt
+++ b/cuda_phase-retrieval/CMakeLists.txt
@@ -11,31 +11,49 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../example_images/
 include_directories(${PYTHON_INCLUDE_DIRS})
 include_directories(${pybind11_INCLUDE_DIR})
 
+set(CMAKE_CUDA_ARCHITECTURES 35 CACHE STRING "CUDA architectures")
+
+set(CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD ${CXX_STANDARD})
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CUDA_STANDARD ${CXX_STANDARD})
+
+# copy example images to build folder
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../example_images/
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/example_images/ )
+
+# this target set ups some properties, which are required for Visual Studio
+# on windows, the build can be done with the Visual Studio or ninja generator
+add_library(msvcHelper INTERFACE)
+if(MSVC)
+  set_target_properties(msvcHelper PROPERTIES SUFFIX ".pyd")
+endif()
+
+if("${CMAKE_GENERATOR}" MATCHES "Visual Studio*")
+  set_target_properties(msvcHelper PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
+  set_target_properties(msvcHelper PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR} )
+  set_target_properties(msvcHelper PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_BINARY_DIR} )
+endif()
+
 add_library(cuPhaseRet SHARED phase_retrieval.cu)
+
+target_include_directories(cuPhaseRet
+  PUBLIC
+  ${PYTHON_INCLUDE_DIRS}
+  ${pybind11_INCLUDE_DIR})
+
 target_link_libraries(cuPhaseRet
+  msvcHelper
   ${PYTHON_LIBRARIES}
   ${OpenCV_LIBS}
   cudart
   cufft
   curand)
 
-set_target_properties(cuPhaseRet PROPERTIES CUDA_STANDARD 14)
 set_target_properties(cuPhaseRet PROPERTIES PREFIX "")
-
-if(MSVC)
-  set_target_properties(cuPhaseRet PROPERTIES SUFFIX ".pyd")
-endif()
-
-# on windows, the build can be done with the Visual Studio or ninja generator
-# this configuration is Visual Studio specific
-if("${CMAKE_GENERATOR}" MATCHES "Visual Studio*")
-  set_target_properties(cuPhaseRet PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
-  set_target_properties(cuPhaseRet PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR} )
-  set_target_properties(cuPhaseRet PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_BINARY_DIR} )
-endif()
 
 # add a custom target for the test.py script, which will copy test.py
 # to the installation folder and update every time there is a change

--- a/cuda_phase-retrieval/CMakeLists.txt
+++ b/cuda_phase-retrieval/CMakeLists.txt
@@ -5,6 +5,9 @@ find_package(PythonInterp 3.6 REQUIRED)
 find_package(PythonLibs 3.6 REQUIRED)
 find_package(pybind11 REQUIRED)
 
+# copy example images to build folder
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../example_images/
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/example_images/ )
 include_directories(${PYTHON_INCLUDE_DIRS})
 include_directories(${pybind11_INCLUDE_DIR})
 
@@ -36,19 +39,19 @@ endif()
 
 # add a custom target for the test.py script, which will copy test.py
 # to the installation folder and update every time there is a change
-add_custom_target(pyTestScript ALL)
-add_custom_command(TARGET pyTestScript PRE_BUILD
+add_custom_target(pyExampleScript ALL)
+add_custom_command(TARGET pyExampleScript PRE_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy
   ${CMAKE_CURRENT_SOURCE_DIR}/example.py $<TARGET_FILE_DIR:cuPhaseRet>
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/example.py)
 
-install(TARGETS cuPhaseRet DESTINATION bin)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/example.py DESTINATION bin)
-
-add_custom_command(TARGET pyTestScript PRE_BUILD
+add_custom_command(TARGET pyExampleScript PRE_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy
   ${CMAKE_CURRENT_SOURCE_DIR}/phase_retrieval_python.py $<TARGET_FILE_DIR:cuPhaseRet>
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/phase_retrieval_python.py)
 
 install(TARGETS cuPhaseRet DESTINATION bin)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/example.py DESTINATION bin)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/phase_retrieval_python.py DESTINATION bin)
+
+add_subdirectory("test/")

--- a/cuda_phase-retrieval/CMakeLists.txt
+++ b/cuda_phase-retrieval/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(${PYTHON_INCLUDE_DIRS})
 include_directories(${pybind11_INCLUDE_DIR})
 
 set(CMAKE_CUDA_ARCHITECTURES 35 CACHE STRING "CUDA architectures")
+set(ENABLE_TEST ON CACHE BOOL "Enable Python binding tests")
 
 set(CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD ${CXX_STANDARD})
@@ -59,4 +60,6 @@ install(TARGETS cuPhaseRet DESTINATION bin)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/example.py DESTINATION bin)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/phase_retrieval_python.py DESTINATION bin)
 
-add_subdirectory("test/")
+if(ENABLE_TEST)
+  add_subdirectory("test/")
+endif()

--- a/cuda_phase-retrieval/CMakeLists.txt
+++ b/cuda_phase-retrieval/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.11)
 project(cuPhaseRet LANGUAGES CXX CUDA)
 
+include("cmake/add_msvc_poperties.cmake")
+
 find_package(PythonInterp 3.6 REQUIRED)
 find_package(PythonLibs 3.6 REQUIRED)
 find_package(pybind11 REQUIRED)
@@ -22,22 +24,6 @@ set(CUDA_STANDARD ${CXX_STANDARD})
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/../example_images/
   DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/example_images/ )
 
-# this target set ups some properties, which are required for Visual Studio
-# on windows, the build can be done with the Visual Studio or ninja generator
-add_library(msvcHelper INTERFACE)
-if(MSVC)
-  set_target_properties(msvcHelper PROPERTIES SUFFIX ".pyd")
-endif()
-
-if("${CMAKE_GENERATOR}" MATCHES "Visual Studio*")
-  set_target_properties(msvcHelper PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
-  set_target_properties(msvcHelper PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR} )
-  set_target_properties(msvcHelper PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_BINARY_DIR} )
-endif()
-
 add_library(cuPhaseRet SHARED phase_retrieval.cu)
 
 target_include_directories(cuPhaseRet
@@ -46,12 +32,13 @@ target_include_directories(cuPhaseRet
   ${pybind11_INCLUDE_DIR})
 
 target_link_libraries(cuPhaseRet
-  msvcHelper
   ${PYTHON_LIBRARIES}
   ${OpenCV_LIBS}
   cudart
   cufft
   curand)
+
+add_msvc_poperties(cuPhaseRet)
 
 set_target_properties(cuPhaseRet PROPERTIES PREFIX "")
 

--- a/cuda_phase-retrieval/cmake/add_msvc_poperties.cmake
+++ b/cuda_phase-retrieval/cmake/add_msvc_poperties.cmake
@@ -1,0 +1,16 @@
+# this target set ups some properties, which are required for Visual Studio
+# on windows, the build can be done with the Visual Studio or ninja generator
+function(add_msvc_poperties tgt)
+  if(MSVC)
+    set_target_properties(${tgt} PROPERTIES SUFFIX ".pyd")
+  endif()
+
+  if("${CMAKE_GENERATOR}" MATCHES "Visual Studio*")
+    set_target_properties(${tgt} PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
+    set_target_properties(${tgt} PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR} )
+    set_target_properties(${tgt} PROPERTIES
+      RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_BINARY_DIR} )
+  endif()
+endfunction()

--- a/cuda_phase-retrieval/example.py
+++ b/cuda_phase-retrieval/example.py
@@ -30,6 +30,11 @@ plt.title('Original Phase Retrieval')
 plt.subplot(223)
 plt.imshow(result_cuda, cmap='gray')
 plt.title('CUDA Phase Retrieval')
-figManager = plt.get_current_fig_manager()
-figManager.window.showMaximized()
+# on headless systems, maximizing the window could be a problem
+try:
+    figManager = plt.get_current_fig_manager()
+    figManager.window.showMaximized()
+except:
+    # simply ignore it, if maximizing is not possible
+    pass
 plt.show()

--- a/cuda_phase-retrieval/example.py
+++ b/cuda_phase-retrieval/example.py
@@ -3,10 +3,10 @@ import numpy as np
 import imageio
 import matplotlib.pyplot as plt
 import phase_retrieval_python
-from time import perf_counter 
+from time import perf_counter
 
 #np.random.seed(1)
-image = imageio.imread('../../example_images/a.png', as_gray=True)
+image = imageio.imread('example_images/a.png', as_gray=True)
 array_random = np.random.rand(*image.shape) #uniform random
 mask = np.ones(image.shape) #default mask
 
@@ -17,7 +17,7 @@ print("Running phase retrieval...")
 result_original = phase_retrieval_python.fienup_phase_retrieval(image, mask, 20, "hybrid", 0.8, array_random)
 result_cuda =  cuPhaseRet.fienup_phase_retrieval(image, mask, 20, "hybrid", 0.8, array_random)
 
-# t1_stop = perf_counter() 
+# t1_stop = perf_counter()
 # print("Elapsed time during the whole program in seconds:", t1_stop-t1_start)
 
 plt.show()

--- a/cuda_phase-retrieval/test/CMakeLists.txt
+++ b/cuda_phase-retrieval/test/CMakeLists.txt
@@ -1,14 +1,6 @@
-cmake_minimum_required(VERSION 3.11)
-project(cuPhaseRet_Test LANGUAGES CXX CUDA)
-
-find_package(PythonInterp 3.6 REQUIRED)
-find_package(PythonLibs 3.6 REQUIRED)
-find_package(pybind11 REQUIRED)
-
 set(OpenCV_STATIC ON)
 find_package( OpenCV 4.5.1 REQUIRED )
 include_directories( ${OpenCV_INCLUDE_DIRS} )
-
 
 include_directories(${PYTHON_INCLUDE_DIRS})
 include_directories(${pybind11_INCLUDE_DIR})
@@ -46,6 +38,3 @@ add_custom_command(TARGET pyTestScript PRE_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy
   ${CMAKE_CURRENT_SOURCE_DIR}/test.py $<TARGET_FILE_DIR:cuPhaseRet_Test>
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/test.py)
-
-install(TARGETS cuPhaseRet_Test DESTINATION bin)
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/test.py DESTINATION bin)

--- a/cuda_phase-retrieval/test/CMakeLists.txt
+++ b/cuda_phase-retrieval/test/CMakeLists.txt
@@ -2,34 +2,22 @@ set(OpenCV_STATIC ON)
 find_package( OpenCV 4.5.1 REQUIRED )
 include_directories( ${OpenCV_INCLUDE_DIRS} )
 
-include_directories(${PYTHON_INCLUDE_DIRS})
-include_directories(${pybind11_INCLUDE_DIR})
-
 add_library(cuPhaseRet_Test SHARED test_binding.cu)
+
+target_include_directories(cuPhaseRet_Test
+  PUBLIC
+  ${PYTHON_INCLUDE_DIRS}
+  ${pybind11_INCLUDE_DIR})
+
 target_link_libraries(cuPhaseRet_Test
+  msvcHelper
   ${PYTHON_LIBRARIES}
   ${OpenCV_LIBS}
   cudart
   cufft
   curand)
 
-set_target_properties(cuPhaseRet_Test PROPERTIES CUDA_STANDARD 14)
 set_target_properties(cuPhaseRet_Test PROPERTIES PREFIX "")
-
-if(MSVC)
-  set_target_properties(cuPhaseRet_Test PROPERTIES SUFFIX ".pyd")
-endif()
-
-# on windows, the build can be done with the Visual Studio or ninja generator
-# this configuration is Visual Studio specific
-if("${CMAKE_GENERATOR}" MATCHES "Visual Studio*")
-  set_target_properties(cuPhaseRet_Test PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} )
-  set_target_properties(cuPhaseRet_Test PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_CURRENT_BINARY_DIR} )
-  set_target_properties(cuPhaseRet_Test PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_CURRENT_BINARY_DIR} )
-endif()
 
 # add a custom target for the test.py script, which will copy test.py
 # to the installation folder and update every time there is a change

--- a/cuda_phase-retrieval/test/CMakeLists.txt
+++ b/cuda_phase-retrieval/test/CMakeLists.txt
@@ -10,12 +10,13 @@ target_include_directories(cuPhaseRet_Test
   ${pybind11_INCLUDE_DIR})
 
 target_link_libraries(cuPhaseRet_Test
-  msvcHelper
   ${PYTHON_LIBRARIES}
   ${OpenCV_LIBS}
   cudart
   cufft
   curand)
+
+add_msvc_poperties(cuPhaseRet_Test)
 
 set_target_properties(cuPhaseRet_Test PROPERTIES PREFIX "")
 

--- a/cuda_phase-retrieval/test/test.py
+++ b/cuda_phase-retrieval/test/test.py
@@ -4,7 +4,7 @@ import imageio
 import matplotlib.pyplot as plt
 
 #still cannot find a way to use pytest with numpy, so I do it manually
-image = imageio.imread('../../../example_images/a.png', as_gray=True)
+image = imageio.imread('../example_images/a.png', as_gray=True)
 magnitudes = np.abs(np.fft.fft2(image))
 mask = np.ones(magnitudes.shape) #default mask
 array_random = np.random.rand(*magnitudes.shape)

--- a/python_bindings_examples/simple_cpp/CMakeLists.txt
+++ b/python_bindings_examples/simple_cpp/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.4...3.18)
 project(cppBinding)
 
-#this is from my local pybind installation
-list(APPEND CMAKE_PREFIX_PATH "D:/Anaconda3/Lib/site-packages/pybind11/share/cmake/pybind11")
 find_package(pybind11 REQUIRED)
 
 pybind11_add_module(cppBinding binding.cpp)

--- a/python_bindings_examples/simple_cuda/CMakeLists.txt
+++ b/python_bindings_examples/simple_cuda/CMakeLists.txt
@@ -3,7 +3,6 @@ project(cuBinding LANGUAGES CXX CUDA)
 
 find_package(PythonInterp 3.6 REQUIRED)
 find_package(PythonLibs 3.6 REQUIRED)
-list(APPEND CMAKE_PREFIX_PATH "D:/Anaconda3/Lib/site-packages/pybind11/share/cmake/pybind11")
 find_package(pybind11 REQUIRED)
 
 include_directories(${PYTHON_INCLUDE_DIRS})


### PR DESCRIPTION
- test are automatically build with the example
- `example_folder` will be copied to the build folder
- introduce cmake argument `CMAKE_CUDA_ARCHITECTURES` to setup the CUDA SM level (e.g. `cmake .. CMAKE_CUDA_ARCHITECTURES=70`)
- introduce cmake helper target `msvcHelper` to remove duplicated code